### PR TITLE
Add logger type

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ function severity(label) {
  * @property {function} options.mixin mixin for additional information in the log statement
  */
 
+/** @typedef {import("pino").Logger} Logger */
+
 /**
  * @param {LoggerOptions} options
- * @return {object} the logger.
+ * @return {Logger} the logger.
  *
  */
 function init(options) {


### PR DESCRIPTION
BNLO are switching to using `exp-logger` as the logger of `Jalla`.
We want the created logger type to be `pino.Logger`. So here's a PR for that.